### PR TITLE
Update Extensions with SDC

### DIFF
--- a/client/app/form-builder/adv-form-builder-def.js
+++ b/client/app/form-builder/adv-form-builder-def.js
@@ -820,15 +820,22 @@ var advFormBuilderDef = {
       "codingInstructions": "Add any copyright notice text you wish to include for this item.",
       "linkId": "/copyrightNotice"
     },
+//    {
+//    "questionCode": "_cqfExpression",
+//      "question": "CQF Expression",
+//      "dataType": "ST",
+//      "header": false,
+//      "codingInstructions": "Add a CQL expression definition ",
+//      "linkId": "/_cqfExpression"
+//    },
     {
-
-    "questionCode": "_cqfExpression",
-      "question": "CQF Expression",
-      "dataType": "ST",
-      "header": false,
-      "codingInstructions": "Add a CQL expression definition ",
-      "linkId": "/_cqfExpression"
-    },
+      "questionCode": "_sdcQuestionnaireCandidateExpression",
+        "question": "SDC Questionnaire Candidate Expression",
+        "dataType": "ST",
+        "header": false,
+        "codingInstructions": "Add a CQL expression definition ",
+        "linkId": "/_sdcQuestionnaireCandidateExpression"
+      },
     {
       "questionCode": "_fhirVariables",
       "question": "FHIR Variable",

--- a/client/app/form-builder/adv-form-builder-def.js
+++ b/client/app/form-builder/adv-form-builder-def.js
@@ -820,14 +820,6 @@ var advFormBuilderDef = {
       "codingInstructions": "Add any copyright notice text you wish to include for this item.",
       "linkId": "/copyrightNotice"
     },
-//    {
-//    "questionCode": "_cqfExpression",
-//      "question": "CQF Expression",
-//      "dataType": "ST",
-//      "header": false,
-//      "codingInstructions": "Add a CQL expression definition ",
-//      "linkId": "/_cqfExpression"
-//    },
     {
       "questionCode": "_sdcQuestionnaireCandidateExpression",
         "question": "SDC Questionnaire Candidate Expression",

--- a/client/app/form-builder/form-builder.service.js
+++ b/client/app/form-builder/form-builder.service.js
@@ -666,10 +666,27 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
             }
           }
           break;
+
         case "_cqfExpression" :
           if(item.value){
           ans = {
             url: "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+            valueExpression: {
+              language: (item.language && item.language.trim !== "") ? item.langauge : "text/cql",
+              expression: item.value
+            }
+          };
+          if(!ret["extension"]) {
+            ret["extension"] = [];
+          }
+          ret["extension"].push(ans);
+        }
+          break;
+
+        case "_sdcQuestionnaireCandidateExpression" :
+          if(item.value){
+          ans = {
+            url: "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
             valueExpression: {
               language: (item.language && item.language.trim !== "") ? item.langauge : "text/cql",
               expression: item.value
@@ -1574,6 +1591,19 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
                   }
   
                   break;
+              case "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression":
+                if(ext.valueExpression && ext.valueExpression.language.toLowerCase() === 'text/cql') {
+                  fieldName = '_sdcQuestionnaireCandidateExpression';
+                  let item = thisService.getFormBuilderField(lfItem.advanced.items, "_sdcQuestionnaireCandidateExpression");
+                  if(item && ext.valueExpression.expression){
+                    item.value = ext.valueExpression.expression
+                  }
+                }
+                else {
+                  hidden = true;
+                }
+
+                break;
               default:
                 hidden = true; // Save unhandled extension as it is.
                 break;
@@ -1865,8 +1895,8 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
    * @param lfItem - Form builder model representing a particular node (item).
    * @param importedExtensionsArray - extension array of the item.
    */
-  function updateCqfExpression(lfItem, importedExtensionsArray) {
-    var field = '_cqfExpression';
+  function updateSdcQuestionnaireCandidateExpression(lfItem, importedExtensionsArray) {
+    var field = '_sdcQuestionnaireCandidateExpression';
     var indexInfo = dataConstants.INITIAL_FIELD_INDICES[field];
     var index = thisService.getFormBuilderFieldIndex(lfItem[indexInfo.category].items, field);
     var aListItems = null;


### PR DESCRIPTION
I switched the cqfExpression extensions to candidateExpression extensions in order to align with the Structured Data Capture IG. 

- I kept the case statements for cqfExpressions in case cqfExpressions ever need to be used for some other reason.
- I updated the `updateCqfExpression()` function to align with the SDC changes (this function was not being called anywhere).

The SDC Questionnaire Candidate Expression form field still only takes in a free-text string, but it now aligns with the questionnaire generation changes made in https://github.com/mcode/ig-to-questionnaire/pull/19/files. 