### PR TITLE
Support all Expression Types for SDC Candidate Expressions

### DIFF
--- a/client/app/form-builder/adv-form-builder-def.js
+++ b/client/app/form-builder/adv-form-builder-def.js
@@ -835,21 +835,13 @@ var advFormBuilderDef = {
           "question": "Language",
           "dataType": "CNE",
           "linkId": "_sdcQuestionnaireCandidateExpression/language",
-          "codingInstructions": "Add an expression definition",
-          "answers": "expressionLanguage",
-          "displayControl": {
-            "answerLayout": {
-              "type": "RADIO_CHECKBOX",
-              "columns": "1"
-            }
-          }
+          "answers": "expressionLanguage"
         },
         {
           "questionCode": "expression",
           "question": "Expresion",
           "dataType": "ST",
           "linkId": "_sdcQuestionnaireCandidateExpression/expression",
-          "codingInstructions": "Add an expression definition"
         }
       ],
       "linkId": "/_sdcQuestionnaireCandidateExpression"

--- a/client/app/form-builder/adv-form-builder-def.js
+++ b/client/app/form-builder/adv-form-builder-def.js
@@ -839,7 +839,7 @@ var advFormBuilderDef = {
         },
         {
           "questionCode": "expression",
-          "question": "Expresion",
+          "question": "Expression",
           "dataType": "ST",
           "linkId": "_sdcQuestionnaireCandidateExpression/expression",
         }

--- a/client/app/form-builder/adv-form-builder-def.js
+++ b/client/app/form-builder/adv-form-builder-def.js
@@ -822,12 +822,38 @@ var advFormBuilderDef = {
     },
     {
       "questionCode": "_sdcQuestionnaireCandidateExpression",
-        "question": "SDC Questionnaire Candidate Expression",
-        "dataType": "ST",
-        "header": false,
-        "codingInstructions": "Add a CQL expression definition ",
-        "linkId": "/_sdcQuestionnaireCandidateExpression"
+      "question": "SDC Questionnaire Candidate Expression",
+      "codingInstructions": "Add an SDC Candidate Answer Expression",
+      "header": true,
+      "questionCardinality": {
+        "min": "1",
+        "max": "*"
       },
+      "items": [
+        {
+          "questionCode": "language",
+          "question": "Language",
+          "dataType": "CNE",
+          "linkId": "_sdcQuestionnaireCandidateExpression/language",
+          "codingInstructions": "Add an expression definition",
+          "answers": "expressionLanguage",
+          "displayControl": {
+            "answerLayout": {
+              "type": "RADIO_CHECKBOX",
+              "columns": "1"
+            }
+          }
+        },
+        {
+          "questionCode": "expression",
+          "question": "Expresion",
+          "dataType": "ST",
+          "linkId": "_sdcQuestionnaireCandidateExpression/expression",
+          "codingInstructions": "Add an expression definition"
+        }
+      ],
+      "linkId": "/_sdcQuestionnaireCandidateExpression"
+    },
     {
       "questionCode": "_fhirVariables",
       "question": "FHIR Variable",

--- a/client/app/form-builder/answer-lists.js
+++ b/client/app/form-builder/answer-lists.js
@@ -2,7 +2,7 @@
  * Answer lists to be used in form builder. The form-builder-data.js has references here
  * to include them in form builder data model.
  *
- * @type {{minCardinality: *[], maxCardinality: *[], boolean: *[], template: *[], questionCodeSystem: *[], _calculationMethod: *[], dataType: *[], editable: *[], testUnits: *[], ucumUnits: *[]}}
+ * @type {{minCardinality: *[], maxCardinality: *[], boolean: *[], template: *[], questionCodeSystem: *[], _calculationMethod: *[], dataType: *[], editable: *[], testUnits: *[], ucumUnits: *[], expressionLanguage: *[]}}
  *
  *
  */
@@ -415,4 +415,18 @@ var answerLists = {
     }
     */
   ],
+  "expressionLanguage": [
+    {
+      "text": "CQL",
+      "code": "text/cql"
+    },
+    {
+      "text": "FHIRPath",
+      "code": "text/fhirpath"
+    },
+    {
+      "text": "FHIR Query",
+      "code": "application/x-fhir-query	"
+    }
+  ]
 };

--- a/client/app/form-builder/answer-lists.js
+++ b/client/app/form-builder/answer-lists.js
@@ -417,16 +417,16 @@ var answerLists = {
   ],
   "expressionLanguage": [
     {
+      "text": "CQL",
+      "code": "text/cql"
+    },
+    {
       "text": "FHIRPath",
       "code": "text/fhirpath"
     },
     {
       "text": "FHIR Query",
       "code": "application/x-fhir-query"
-    },
-    {
-      "text": "CQL",
-      "code": "text/cql"
     }
   ]
 };

--- a/client/app/form-builder/answer-lists.js
+++ b/client/app/form-builder/answer-lists.js
@@ -417,16 +417,16 @@ var answerLists = {
   ],
   "expressionLanguage": [
     {
-      "text": "CQL",
-      "code": "text/cql"
-    },
-    {
       "text": "FHIRPath",
       "code": "text/fhirpath"
     },
     {
       "text": "FHIR Query",
       "code": "application/x-fhir-query"
+    },
+    {
+      "text": "CQL",
+      "code": "text/cql"
     }
   ]
 };

--- a/client/app/form-builder/answer-lists.js
+++ b/client/app/form-builder/answer-lists.js
@@ -426,7 +426,7 @@ var answerLists = {
     },
     {
       "text": "FHIR Query",
-      "code": "application/x-fhir-query	"
+      "code": "application/x-fhir-query"
     }
   ]
 };

--- a/client/app/form-builder/form-builder.service.js
+++ b/client/app/form-builder/form-builder.service.js
@@ -688,7 +688,7 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
             ans = {
               url: "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
               valueExpression: {
-                language: (item.items[0].value) ? item.items[0].value.code : "text/cql",
+                language: (item.items[0].value) ? item.items[0].value.code : "FHIRPath",
                 expression: item.items[1].value
               }
             };
@@ -1598,11 +1598,32 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
                 if (ext.valueExpression && ( (lang === 'text/cql') || (lang === 'text/fhirpath') || (lang === 'application/x-fhir-query') ) ) {
                   let item = thisService.getFormBuilderField(lfItem.advanced.items, "_sdcQuestionnaireCandidateExpression");
                   if(item) {
-                    item.items[0].value = expression;
-                    if (ext.valuleExpression.expression){
+                    console.log(item);
+                    switch (lang) {
+                      case 'text/fhirpath':
+                        langValue = {
+                          code: "text/fhirpath",
+                          text: "FHIRPath"
+                        };
+                        break;
+                      case 'application/x-fhir-query':
+                        langValue = {
+                          code: "application/x-fhir-query",
+                          text: "FHIR Query"
+                        };
+                        break;
+                      default:
+                        langValue = {
+                          code: "text/cql",
+                          text: "CQL"
+                        };
+                    }
+                    item.items[0].value = langValue;
+                    if (ext.valueExpression.expression){
                       item.items[1].value = ext.valueExpression.expression;
                     }
                   }
+                  console.log(item);
                 }
                 else {
                   hidden = true;

--- a/client/app/form-builder/form-builder.service.js
+++ b/client/app/form-builder/form-builder.service.js
@@ -684,11 +684,11 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
           break;
 
         case "_sdcQuestionnaireCandidateExpression" :
-          if(item.items[1].value){
+          if(item.items[1].value) {
             ans = {
               url: "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
               valueExpression: {
-                language: (item.items[0].value) ? item.items[0].value.code : "FHIRPath",
+                language: (item.items[0].value) ? item.items[0].value.code : "text/cql",
                 expression: item.items[1].value
               }
             };
@@ -696,7 +696,6 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
               ret["extension"] = [];
             }
             ret["extension"].push(ans);
-
           }
           break;
         case "_fhirVariables":
@@ -1557,7 +1556,6 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
       case "extension":
         if(val) {
           var varExtensions = [];
-          var sdcExtensions = [];
           var hiddenList = val.filter(function (ext) {
             var hidden = false;
             var calFieldName = null;
@@ -1585,7 +1583,7 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
                     fieldName = '_cqfExpression';
                     let item = thisService.getFormBuilderField(lfItem.advanced.items, "_cqfExpression");
                     if(item && ext.valueExpression.expression){
-                      item.value = ext.valueExpression.expression;
+                      item.value = ext.valueExpression.expression
                     }
                   }
                   else {
@@ -1594,43 +1592,39 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
   
                   break;
               case "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression":
-                let lang = ext.valueExpression.language.toLowerCase();
-                if (ext.valueExpression && ( (lang === 'text/cql') || (lang === 'text/fhirpath') || (lang === 'application/x-fhir-query') ) ) {
+                let languageCode = (ext.valueExpression) ? ext.valueExpression.language.toLowerCase() : '';
+                if (ext.valueExpression && ( (languageCode === 'text/cql') || (languageCode === 'text/fhirpath') || (languageCode === 'application/x-fhir-query') ) ) {
                   let item = thisService.getFormBuilderField(lfItem.advanced.items, "_sdcQuestionnaireCandidateExpression");
                   if(item) {
-                    console.log(item);
-                    switch (lang) {
+                    switch (languageCode) {
                       case 'text/fhirpath':
-                        langValue = {
+                        languageObj = {
                           code: "text/fhirpath",
                           text: "FHIRPath"
                         };
                         break;
                       case 'application/x-fhir-query':
-                        langValue = {
+                        languageObj = {
                           code: "application/x-fhir-query",
                           text: "FHIR Query"
                         };
                         break;
                       default:
-                        langValue = {
+                        languageObj = {
                           code: "text/cql",
                           text: "CQL"
                         };
                     }
-                    item.items[0].value = langValue;
+                    item.items[0].value = languageObj;
                     if (ext.valueExpression.expression){
                       item.items[1].value = ext.valueExpression.expression;
                     }
                   }
-                  console.log(item);
                 }
                 else {
                   hidden = true;
                 }
-
                 break;
-
               default:
                 hidden = true; // Save unhandled extension as it is.
                 break;
@@ -1929,11 +1923,11 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
     if(importedExtensionsArray && lodash.isArray(importedExtensionsArray)) {
       aListItems = [];
       lodash.forEach(importedExtensionsArray, function(x) {
-        lang = x.valueExpression.language.toLowerCase();
-        if( (lang === 'text/cql') || (lang === 'text/fhirpath') || (lang === 'application/x-fhir-query')) {
+        if(x.valueExpression.language.toLowerCase() === 'text/cql') {
           var item = angular.copy(lfItem[indexInfo.category].items[index]);
-          item.items[0].value = x.valueExpression.language;
+          item.items[0].value = x.valueExpression.name;
           item.items[1].value = x.valueExpression.expression;
+          item.items[2].value = x.valueExpression.description;
           aListItems.push(item);
         }
       });

--- a/client/app/form-builder/form-builder.service.js
+++ b/client/app/form-builder/form-builder.service.js
@@ -688,8 +688,8 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
             ans = {
               url: "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
               valueExpression: {
-                language: (item.items[0].value) ? item.items[0].value : "text/cql",
-                expression: item.items[0].value
+                language: (item.items[0].value) ? item.items[0].value.code : "text/cql",
+                expression: item.items[1].value
               }
             };
             if(!ret["extension"]) {
@@ -1585,7 +1585,7 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
                     fieldName = '_cqfExpression';
                     let item = thisService.getFormBuilderField(lfItem.advanced.items, "_cqfExpression");
                     if(item && ext.valueExpression.expression){
-                      item.value = ext.valueExpression.expression
+                      item.value = ext.valueExpression.expression;
                     }
                   }
                   else {
@@ -1595,19 +1595,21 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
                   break;
               case "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression":
                 let lang = ext.valueExpression.language.toLowerCase();
-                if(lang && ( (lang === 'text/cql') || (lang === 'text/fhirpath') || (lang === 'application/x-fhir-query') ) ) {
-                  fieldName = '_sdcQuestionnaireCandidateExpression';
+                if (ext.valueExpression && ( (lang === 'text/cql') || (lang === 'text/fhirpath') || (lang === 'application/x-fhir-query') ) ) {
                   let item = thisService.getFormBuilderField(lfItem.advanced.items, "_sdcQuestionnaireCandidateExpression");
-                  if(item && ext.valueExpression.expression){
-                    item.value = ext.valueExpression.expression
+                  if(item) {
+                    item.items[0].value = expression;
+                    if (ext.valuleExpression.expression){
+                      item.items[1].value = ext.valueExpression.expression;
+                    }
                   }
-                  varExtensions.push(ext)
                 }
                 else {
                   hidden = true;
                 }
 
                 break;
+
               default:
                 hidden = true; // Save unhandled extension as it is.
                 break;
@@ -1616,7 +1618,6 @@ fb.service('formBuilderService', ['$window', 'lodash', '$q', '$http', 'dataConst
           });
 
           updateVariables(lfItem, varExtensions);
-          updateSdcQuestionnaireCandidateExpression(lfItem, sdcExtensions)
           addAsHidden(lfItem, name, hiddenList);
         }
         break;


### PR DESCRIPTION
Adds support for all Expression Languages within SDC Candidate Expression Extensions, per [OSHRQ-65](https://jira.mitre.org/browse/OSHRQ-65).

Previously, [SDC Candidate Expressions](http://build.fhir.org/ig/HL7/sdc/StructureDefinition-sdc-questionnaire-candidateExpression.html) were assumed to be written in CQL. Now they can support all 3 Expression Languages defined in the [ExpressionLanguage Code system value set](http://hl7.org/fhir/R4/codesystem-expression-language.html). Should support both importing and exporting questionnaires with Candidate Expression extensions that use one of the three languages defined in the value set.

**To test:**
Clone and run a local version of this cqfSupport branch of the formbuilder.
*Export*:
Import `mcode-questionnaire.json` from abstraction-tool/public/static. Change the SDC Questionnaire Candidate Expression "Language" and "Expression" under one of items' "Item Attributes - Advanced" column. Referesh the JSON output, and you should see the updated expression in the questionnaire preview.
*Import*:
Download the modified `mcode-questionnaire.json` from above directly from the form builder tool. Then re-upload the downloaded questionnaire to the formbuilder. The modified items should pre-populate with the modified "Language" and "Expression" fields.

**Edge Case:**
I configured the export so that if no Language is entered, but an expression is entered, the questionnaire export will default to setting the language as CQL, since `language` is the one required attribute for a [FHIR Expression](https://www.hl7.org/fhir/metadatatypes.html#Expression).
